### PR TITLE
fix: Ensure isMounted is reactive

### DIFF
--- a/src/lib/AnimatedBlock.svelte
+++ b/src/lib/AnimatedBlock.svelte
@@ -5,11 +5,9 @@
 	let { children }: { children: Snippet } = $props();
 
 	const streamdown = useStreamdown();
-
-	const isMounted = streamdown.isMounted;
 </script>
 
-{#if isMounted}
+{#if streamdown.isMounted}
 	<div style={streamdown.animationBlockStyle}>
 		{@render children()}
 	</div>

--- a/src/lib/AnimatedText.svelte
+++ b/src/lib/AnimatedText.svelte
@@ -21,11 +21,9 @@
 	let tokens = $derived.by(() => {
 		return tokenizeNewContent(text);
 	});
-
-	const isMounted = streamdown.isMounted;
 </script>
 
-{#if isMounted}
+{#if streamdown.isMounted}
 	<span>
 		{#each tokens as token}
 			<span style={streamdown.animationTextStyle}>

--- a/src/lib/Elements/Element.svelte
+++ b/src/lib/Elements/Element.svelte
@@ -12,8 +12,6 @@
 	import FootnoteRef from './FootnoteRef.svelte';
 	let { token, children }: { token: StreamdownToken; children: Snippet } = $props();
 	const streamdown = useStreamdown();
-
-	const isMounted = streamdown.isMounted;
 </script>
 
 {#if token.type === 'heading'}
@@ -93,7 +91,7 @@
 {:else if token.type === 'list_item'}
 	<Slot props={{ children, token }} render={streamdown.snippets.li}>
 		<li
-			style={isMounted ? streamdown.animationBlockStyle : undefined}
+			style={streamdown.isMounted ? streamdown.animationBlockStyle : undefined}
 			style:list-style-type={token.task ? 'none' : undefined}
 			{...token.value && !token.task ? { value: token.value } : {}}
 			class={streamdown.theme.li.base}

--- a/src/lib/Elements/FootnoteRef.svelte
+++ b/src/lib/Elements/FootnoteRef.svelte
@@ -79,7 +79,6 @@
 			off();
 		};
 	};
-	const isMounted = streamdown.isMounted;
 </script>
 
 {#if isOpen}
@@ -113,7 +112,7 @@
 	render={streamdown.snippets.footnoteRef}
 >
 	<button
-		style={isMounted ? streamdown.animationBlockStyle : ''}
+		style={streamdown.isMounted ? streamdown.animationBlockStyle : ''}
 		bind:this={reference}
 		class={streamdown.theme.footnoteRef.base}
 		onclick={() => (isOpen = !isOpen)}

--- a/src/lib/Elements/Math.svelte
+++ b/src/lib/Elements/Math.svelte
@@ -45,13 +45,11 @@
 			});
 		}
 	});
-
-	const isMounted = streamdown.isMounted;
 </script>
 
 {#if isInline}
 	<span
-		style={isMounted ? streamdown.animationBlockStyle : ''}
+		style={streamdown.isMounted ? streamdown.animationBlockStyle : ''}
 		bind:this={inner}
 		class={streamdown.theme.math.inline}
 	>


### PR DESCRIPTION
Fixes an issue where sometimes animations won't work.

I suppose another solution would be to just wrap it in a $derived but I don't see the need given we are just using it in one place.